### PR TITLE
fix: older interface for `README.md`

### DIFF
--- a/packages/transform/README.md
+++ b/packages/transform/README.md
@@ -35,22 +35,23 @@ npm install @joshdb/transform
 ## Middleware Context Data
 
 ```typescript
-interface ContextData<StoredValue = unknown> {
+interface ContextData<BeforeValue = unknown, AfterValue = unknown> extends JoshMiddleware.Context {
   /**
    * Manipulates the data before it is stored by the provider.
    * @since 1.0.0
    */
-  before: (data: BeforeValue, key: string | string[] | null, path: string[] | null): AfterValue;
+  before: (data: BeforeValue, key: string | string[] | null, path: string[] | null) => AfterValue;
 
   /**
-   * Normalises the data after it is retrieved from the provider.
+   * Normalizes the data after it is retrieved from the provider.
    * @since 1.0.0
    */
-  after: (data: AfterValue, key: string | string[] | null, path: string[] | null): BeforeValue;
+  after: (data: AfterValue, key: string | string[] | null, path: string[] | null) => BeforeValue;
 
   /**
    * Manipulates any existing data to the appropriate format.
    * @since 1.0.0
+   * @default false
    */
   autoTransform?: boolean;
 }


### PR DESCRIPTION
A small change to the `README.md` to show the same interface used in the middleware, this was missed in be0794dfcc30f40740c1f1b668af7a1b2dafc598 (my bad)